### PR TITLE
Fix error when destroy in add once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.0.1
+* `Trigger#addOnce()` のハンドラ内で `destroy()` が呼ばれるた際にクラッシュしたしまうバグを修正
+
 ## 1.0.0
 * `Trigger` にジェネリクスが指定された場合は `Trigger#fire()` の引数を省略不可に
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.0.1
-* `Trigger#addOnce()` のハンドラ内で `destroy()` が呼ばれるた際にクラッシュしたしまうバグを修正
+* `Trigger#addOnce()` のハンドラ内で `destroy()` が呼ばれた際にクラッシュしてしまうバグを修正
 
 ## 1.0.0
 * `Trigger` にジェネリクスが指定された場合は `Trigger#fire()` の引数を省略不可に

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/trigger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/trigger",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@akashic/eslint-config": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/trigger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An event emitting module for TypeScript",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/spec/src/TriggerSpec.ts
+++ b/spec/src/TriggerSpec.ts
@@ -754,6 +754,16 @@ describe("Triggerの異常系テスト", () => {
 		expect(order).toEqual([1, 2, 3]);
 	});
 
+	it("addOnce()でfire()中にdestroy()した場合でも正常に動作する ", () => {
+		const trigger = new Trigger<void>();
+		trigger.addOnce((): void => {
+			trigger.destroy();
+		});
+		trigger.fire();
+		expect(trigger.destroyed()).toBeTrue();
+		expect(trigger._handlers).toBeNull();
+	});
+
 	it("ハンドラが削除されれば、fireしても関数は動作しない", () => {
 		let counter = 0;
 		const mockHandle = (): void => {

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -138,6 +138,8 @@ export class Trigger<T = void> implements TriggerLike<T> {
 		for (let i = 0; i < handlers.length; i++) {
 			const handler = handlers[i];
 			if (handler.func.call(handler.owner, arg) || handler.once) {
+				if (!this._handlers)
+					return;
 				const index = this._handlers.indexOf(handler);
 				if (index !== -1)
 					this._handlers.splice(index, 1);

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -139,7 +139,7 @@ export class Trigger<T = void> implements TriggerLike<T> {
 			const handler = handlers[i];
 			if (handler.func.call(handler.owner, arg) || handler.once) {
 				if (!this._handlers)
-					return;
+					continue;
 				const index = this._handlers.indexOf(handler);
 				if (index !== -1)
 					this._handlers.splice(index, 1);


### PR DESCRIPTION
## 概要

`Trigger#addOnce()` のハンドラ内で `destroy()` が実行されるとクラッシュする問題を修正。

